### PR TITLE
feat: add eth_call_override

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,20 @@
+name: Docker
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  docker:
+    with:
+      ci-lint-skip: true
+      ci-test-skip: true
+      dockerfile: Dockerfile
+    uses: node-real/github-workflows/.github/workflows/ci-pr.yml@v1
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,58 @@
+name: CI Tests
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
+
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run unit tests
+        run: make test
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
+
+      - name: Cache Go modules
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run integration tests
+        run: go test ./integration_tests/...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM golang:1.21.3-alpine3.18 as builder
 
-
 RUN apk add make jq git gcc musl-dev linux-headers
 
 COPY ./proxyd /app

--- a/config.go
+++ b/config.go
@@ -204,6 +204,16 @@ type SenderRateLimitConfig struct {
 	AllowedChainIds []*big.Int `toml:"allowed_chain_ids"`
 }
 
+type EthCallRule struct {
+	Address string `toml:"address"`
+	Value   string `toml:"value"`
+	Result  string `toml:"result"`
+}
+
+type EthCallOverrideConfig struct {
+	Rules []EthCallRule `toml:"rules"`
+}
+
 type Config struct {
 	WSBackendGroup        string                `toml:"ws_backend_group"`
 	Server                ServerConfig          `toml:"server"`
@@ -220,6 +230,7 @@ type Config struct {
 	WSMethodWhitelist     []string              `toml:"ws_method_whitelist"`
 	WhitelistErrorMessage string                `toml:"whitelist_error_message"`
 	SenderRateLimit       SenderRateLimitConfig `toml:"sender_rate_limit"`
+	EthCallOverride       EthCallOverrideConfig `toml:"eth_call_override"`
 }
 
 func ReadFromEnvOrConfig(value string) (string, error) {

--- a/example.config.toml
+++ b/example.config.toml
@@ -1,11 +1,11 @@
 # List of WS methods to whitelist.
-ws_method_whitelist = [
-  "eth_subscribe",
-  "eth_call",
-  "eth_chainId"
-]
+# ws_method_whitelist = [
+#  "eth_subscribe",
+#  "eth_call",
+#  "eth_chainId"
+# ]
 # Enable WS on this backend group. There can only be one WS-enabled backend group.
-ws_backend_group = "main"
+# ws_backend_group = "main"
 
 [server]
 # Host for the proxyd RPC server to listen on.
@@ -16,7 +16,7 @@ rpc_port = 8080
 ws_host = "0.0.0.0"
 # Port for the above
 # Set the ws_port to 0 to disable WS
-ws_port = 8085
+ws_port = 0
 # Maximum client body size, in bytes, that the server will accept.
 max_body_size_bytes = 10485760
 max_concurrent_rpcs = 1000
@@ -53,10 +53,10 @@ max_error_rate_threshold = 0.3
 
 [backends]
 # A map of backends by name.
-[backends.infura]
+[backends.nodereal]
 # The URL to contact the backend at. Will be read from the environment
 # if an environment variable prefixed with $ is provided.
-rpc_url = ""
+rpc_url = "https://bsc-mainnet-builder.nodereal.io"
 # The WS URL to contact the backend at. Will be read from the environment
 # if an environment variable prefixed with $ is provided.
 ws_url = ""
@@ -64,32 +64,24 @@ username = ""
 # An HTTP Basic password to authenticate with the backend. Will be read from
 # the environment if an environment variable prefixed with $ is provided.
 password = ""
-max_rps = 3
-max_ws_conns = 1
+# max_rps = 3
+# max_ws_conns = 1
 # Path to a custom root CA.
 ca_file = ""
 # Path to a custom client cert file.
 client_cert_file = ""
 # Path to a custom client key file.
 client_key_file = ""
-# Allows backends to skip peer count checking, default false
-# consensus_skip_peer_count = true
-# Specified the target method to get receipts, default "debug_getRawReceipts"
-# See https://github.com/ethereum-optimism/optimism/blob/186e46a47647a51a658e699e9ff047d39444c2de/op-node/sources/receipts.go#L186-L253
-consensus_receipts_target = "eth_getBlockReceipts"
 
-[backends.alchemy]
-rpc_url = ""
-ws_url = ""
-username = ""
-password = ""
-max_rps = 3
-max_ws_conns = 1
-consensus_receipts_target = "alchemy_getTransactionReceipts"
+[backends.48club]
+rpc_url = "https://puissant-builder.48.club/"
+
+[backends.blockrazor]
+rpc_url = "https://rpc.blockrazor.builders/"
 
 [backend_groups]
 [backend_groups.main]
-backends = ["infura"]
+backends = ["nodereal", "48club", "blockrazor"]
 # Enable consensus awareness for backend group, making it act as a load balancer, default false
 # consensus_aware = true
 # Period in which the backend wont serve requests if banned, default 5m
@@ -103,8 +95,12 @@ backends = ["infura"]
 # Minimum peer count, default 3
 # consensus_min_peer_count = 4
 
-[backend_groups.alchemy]
-backends = ["alchemy"]
+# A backend group that uses the "multicall" routing strategy
+# to fan out requests to all backends in the group and return
+# the first successful response.
+[backend_groups.broadcast_group]
+backends = ["nodereal", "48club", "blockrazor"]
+routing_strategy = "multicall"
 
 # If the authentication group below is in the config,
 # proxyd will only accept authenticated requests.
@@ -118,6 +114,36 @@ secret = "test"
 
 # Mapping of methods to backend groups.
 [rpc_method_mappings]
-eth_call = "main"
+# wallet support
+eth_blockNumber = "main"
 eth_chainId = "main"
-eth_blockNumber = "alchemy"
+eth_gasPrice = "main"
+eth_getBalance = "main"
+eth_getBlockByNumber = "main"
+eth_getTransactionCount = "main"
+eth_getTransactionReceipt = "main"
+eth_maxPriorityFeePerGas = "main"
+net_version = "main"
+
+eth_call = "main"
+eth_estimateGas = "main"
+eth_sendRawTransaction = "broadcast_group"
+
+[eth_call_override]
+# 48Club
+[[eth_call_override.rules]]
+address = "0x0000000000000000000000000000000000000048"
+value = "0x30"
+result = "\"0x30\""
+
+# Blockrazor
+[[eth_call_override.rules]]
+address = "0x0000000000000000000000000000000000000100"
+value = "0x64"
+result = "\"0x64\""
+
+[rate_limit]
+base_rate = 5
+base_interval = "1s"
+# exempt_origins = ["https://admin.example.com"]
+# exempt_user_agents = []

--- a/integration_tests/eth_call_override_test.go
+++ b/integration_tests/eth_call_override_test.go
@@ -1,0 +1,188 @@
+package integration_tests
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEthCallOverride(t *testing.T) {
+	config := ReadConfig("eth_call_override")
+
+	// Create a mock backend that handles non-override calls
+	hdlr := NewBatchRPCResponseRouter()
+	hdlr.SetRoute("eth_call", "999", "mock_backend_response")
+
+	backend := NewMockBackend(hdlr)
+	defer backend.Close()
+
+	require.NoError(t, os.Setenv("MAIN_BACKEND_RPC_URL", backend.URL()))
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	tests := []struct {
+		name             string
+		toAddress        string
+		value            interface{}
+		expectedRes      string
+		shouldHitBackend bool
+	}{
+		{
+			name:             "match",
+			toAddress:        "0xaBcD123456789012345678901234567890123456",
+			value:            "0xaBcD1234",
+			expectedRes:      "0x1000",
+			shouldHitBackend: false,
+		},
+		{
+			name:             "match - case insensitive",
+			toAddress:        "0xAbCd123456789012345678901234567890123456",
+			value:            "0xAbCd1234",
+			expectedRes:      "0x1000",
+			shouldHitBackend: false,
+		},
+		{
+			name:             "no match - different address",
+			toAddress:        "0x1111111111111111111111111111111111111111",
+			value:            "0x0",
+			expectedRes:      "mock_backend_response",
+			shouldHitBackend: true,
+		},
+		{
+			name:             "no match - same address but different value",
+			toAddress:        "0x1234567890123456789012345678901234567890",
+			value:            "0x1",
+			expectedRes:      "mock_backend_response",
+			shouldHitBackend: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend.Reset()
+
+			// Prepare eth_call parameters
+			var params []interface{}
+			callData := map[string]interface{}{
+				"to": tt.toAddress,
+			}
+			if tt.value != nil {
+				callData["value"] = tt.value
+			}
+			params = append(params, callData, "latest")
+
+			res, statusCode, err := client.SendRPC("eth_call", params)
+			require.NoError(t, err)
+			require.Equal(t, 200, statusCode)
+
+			// Parse response to check result
+			var jsonRes map[string]interface{}
+			require.NoError(t, json.Unmarshal(res, &jsonRes))
+
+			if tt.shouldHitBackend {
+				// Should forward to backend
+				require.Equal(t, 1, len(backend.Requests()))
+				require.Equal(t, tt.expectedRes, jsonRes["result"])
+			} else {
+				// Should be handled by override
+				require.Equal(t, 0, len(backend.Requests()))
+				require.Equal(t, tt.expectedRes, jsonRes["result"])
+			}
+		})
+	}
+}
+
+func TestEthCallOverride48Club(t *testing.T) {
+	config := ReadConfig("eth_call_override")
+
+	// Create a mock backend
+	hdlr := NewBatchRPCResponseRouter()
+	hdlr.SetRoute("eth_call", "999", "should_not_be_called")
+
+	backend := NewMockBackend(hdlr)
+	defer backend.Close()
+
+	require.NoError(t, os.Setenv("MAIN_BACKEND_RPC_URL", backend.URL()))
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+	_, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+	defer shutdown()
+
+	tests := []struct {
+		name        string
+		toAddress   string
+		value       string
+		rpcURL      string
+		description string
+	}{
+		{
+			name:        "48Club override rule",
+			toAddress:   "0x0000000000000000000000000000000000000048",
+			value:       "0x30",
+			rpcURL:      "https://bscrpc.pancakeswap.finance",
+			description: "Compare proxyd override result with direct 48Club RPC call",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := []interface{}{
+				map[string]interface{}{
+					"to":    tt.toAddress,
+					"value": tt.value,
+				},
+				"latest",
+			}
+
+			// 1. Get result from proxyd (should use override)
+			backend.Reset()
+			proxydRes, statusCode, err := client.SendRPC("eth_call", params)
+			require.NoError(t, err)
+			require.Equal(t, 200, statusCode)
+
+			var proxydJSON map[string]interface{}
+			require.NoError(t, json.Unmarshal(proxydRes, &proxydJSON))
+
+			// Should be handled by override (no backend calls)
+			require.Equal(t, 0, len(backend.Requests()))
+
+			// 2. Get result from direct RPC call to the external service
+			directClient := NewProxydClient(tt.rpcURL)
+			directRes, directStatusCode, directErr := directClient.SendRPC("eth_call", params)
+
+			if directErr != nil {
+				t.Fatalf("Direct RPC call failed: %v", directErr)
+				return
+			}
+
+			if directStatusCode != 200 {
+				t.Fatalf("Direct RPC call returned non-200 status %d", directStatusCode)
+				return
+			}
+
+			var directJSON map[string]interface{}
+			require.NoError(t, json.Unmarshal(directRes, &directJSON))
+
+			if directJSON["result"] != nil {
+				t.Logf("Direct RPC result: %v", directJSON["result"])
+				t.Logf("Proxyd override result: %v", proxydJSON["result"])
+
+				// Check if results match
+				if directJSON["result"] == proxydJSON["result"] {
+					t.Logf("✅ Results match: %s", tt.description)
+				} else {
+					t.Fatalf("⚠️ Results differ: %s", tt.description)
+				}
+			} else {
+				t.Fatalf("Direct RPC call returned error: %v", directJSON["error"])
+			}
+		})
+	}
+}

--- a/integration_tests/testdata/eth_call_override.toml
+++ b/integration_tests/testdata/eth_call_override.toml
@@ -1,0 +1,38 @@
+[server]
+rpc_host = "127.0.0.1"
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 5
+max_response_size_bytes = 5242880
+
+[backends]
+[backends.main]
+rpc_url = "$MAIN_BACKEND_RPC_URL"
+max_rps = 3
+
+[backend_groups]
+[backend_groups.main]
+backends = ["main"]
+
+[rpc_method_mappings]
+eth_call = "main"
+eth_chainId = "main"
+
+[eth_call_override]
+# 48Club
+[[eth_call_override.rules]]
+address = "0x0000000000000000000000000000000000000048"
+value = "0x30"
+result = "\"0x30\""
+
+# Blockrazor
+[[eth_call_override.rules]]
+address = "0x0000000000000000000000000000000000000100"
+value = "0x64"
+result = "\"0x64\""
+
+[[eth_call_override.rules]]
+address = "0xaBcD123456789012345678901234567890123456"
+value = "0xaBcD1234"
+result = "\"0x1000\""

--- a/proxyd.go
+++ b/proxyd.go
@@ -353,6 +353,7 @@ func Start(config *Config) (*Server, func(), error) {
 		config.Server.MaxRequestBodyLogLen,
 		config.BatchConfig.MaxSize,
 		limiterFactory,
+		config.EthCallOverride.Rules,
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)


### PR DESCRIPTION
## Summary

This PR adds an eth_call_override feature to proxyd that allows configuring predefined responses for specific `eth_call` requests based on to address and value combinations. This feature is designed to help RPC endpoints pass BSC's MEV guard verification checks.

## Background

Some BSC protocols perform MEV guard checks by sending specific `eth_call` requests to RPC endpoints. The eth_call_override functionality enables RPC services to return the required responses for these verification calls without forwarding them to backend nodes.

## Changes

### Core Features

- New Configuration Section: Added [eth_call_override] configuration block supporting multiple rules
- Request Matching: Matches incoming eth_call requests by to address and value fields
- Case-Insensitive Matching: Address and value matching is case-insensitive

### Configuration Format

```toml
[eth_call_override]
[[eth_call_override.rules]]
address = "0x1234567890123456789012345678901234567890"
value = "0x01"
result = "\"0x01\""
```